### PR TITLE
Fix installation issues on latest Debian/Ubuntu releases

### DIFF
--- a/engine/lib/jaw/aliasing/aliasing.cpp
+++ b/engine/lib/jaw/aliasing/aliasing.cpp
@@ -5,6 +5,7 @@
 #include "./json.hpp"
 #include <thread>
 #include <shared_mutex>
+#include <mutex>
 
 std::shared_mutex rw_mutex;
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# make sure the package index is up-to-date
+sudo apt update
+
 # chromimum
 sudo apt install -y chromium-browser
 


### PR DESCRIPTION
This pull request adds a safety check to the installation script and fixes a compilation error for `aliasing.cpp` encountered on our end.

** install.sh **

We added an `$ apt update` at the beginning of the installation process to prevent potential package download errors.

** engine/lib/jaw/aliasing/aliasing.cpp **

We included an additional "mutex.h" header to patch a compilation error encountered on our Ubuntu 22.04.4 LTS system.