### PR TITLE
Fix a few minor issues with the pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,104 +1,104 @@
 # 1. which webapps to test?
 testbed: 
-	## option 1: test a specifc website
-	site: https://google.com
-	## option 2: provide a top-site list (e.g., Alexa, Tranco, etc)
-	sitelist: /input/tranco_Z2QWG_unique.csv
-	from_row: 1
-	to_row: 5000
+  ## option 1: test a specifc website
+  site: https://google.com
+  ## option 2: provide a top-site list (e.g., Alexa, Tranco, etc)
+  sitelist: /input/tranco_Z2QWG_unique.csv
+  from_row: 1
+  to_row: 5000
 
 
 # 2. crawler configuration
 crawler:
-	# max number of urls to visit
-	maxurls: 30
-	# time budget for crawling each site in seconds
-	sitetimeout: 1800 # 30 mins;
-	# amount of memory for the crawler
-	memory: 8192
-	# overwrite already existing crawled data or not
-	overwrite: false
-	# check if domain is up with a python request before spawning a browser instance
-	domain_health_check: false
- 
-	# browser to use for crawling
-	browser:
-		name: firefox # options are `chrome` (crawler.js) and `firefox` (crawler-taint.js)
-		headless: true
-		# use foxhound if firefox is enabled (default is true)
-		foxhound: true 
+  # max number of urls to visit
+  maxurls: 30
+  # time budget for crawling each site in seconds
+  sitetimeout: 1800 # 30 mins;
+  # amount of memory for the crawler
+  memory: 8192
+  # overwrite already existing crawled data or not
+  overwrite: false
+  # check if domain is up with a python request before spawning a browser instance
+  domain_health_check: false
+
+  # browser to use for crawling
+  browser:
+    name: firefox # options are `chrome` (crawler.js) and `firefox` (crawler-taint.js)
+    headless: true
+    # use foxhound if firefox is enabled (default is true)
+    foxhound: true 
 
 # 3. static analysis configuration
 staticpass:
-	# time budget for static analysis of each site (in seconds)
-	sitetimeout: 10800 # 3 hrs
-	# enforce a max per webpage timeout when `sitetimeout` is not used (in seconds)
-	pagetimeout: 600
-	# iteratively write the graph output to disk (useful in case of timeouts for partial results)
-	iterativeoutput: false
-	# max amount of available memory for static analysis per process
-	memory: 32000
-	# compress the property graph or not
-	compress_hpg: true
-	# overwrite the existing graphs or not
-	overwrite_hpg: false
-	# neo4j instance config
-	neo4j_user: neo4j
-	neo4j_pass: root
-	neo4j_http_port: '7474'
-	# bolt port will default to http port + 2 with ineo 
-	# otherwise, specify another port here
-	neo4j_bolt_port: '7476'
-	neo4j_use_docker: false
+  # time budget for static analysis of each site (in seconds)
+  sitetimeout: 10800 # 3 hrs
+  # enforce a max per webpage timeout when `sitetimeout` is not used (in seconds)
+  pagetimeout: 600
+  # iteratively write the graph output to disk (useful in case of timeouts for partial results)
+  iterativeoutput: false
+  # max amount of available memory for static analysis per process
+  memory: 32000
+  # compress the property graph or not
+  compress_hpg: true
+  # overwrite the existing graphs or not
+  overwrite_hpg: false
+  # neo4j instance config
+  neo4j_user: neo4j
+  neo4j_pass: root
+  neo4j_http_port: '7474'
+  # bolt port will default to http port + 2 with ineo 
+  # otherwise, specify another port here
+  neo4j_bolt_port: '7476'
+  neo4j_use_docker: false
 
 # 4. dynamic analysis configuration
 dynamicpass:
-	# time budget for dynamic analysis of each site in seconds
-	sitetimeout: 10800 # 3 hrs
-	# which browser to use
-	browser:
-		name: chrome
-		# use remote browserstack browsers or not
-		use_browserstack: false
-		browserstack_username: xyz
-		browserstack_password: xyz
-		browserstack_access_key: xyz
+  # time budget for dynamic analysis of each site in seconds
+  sitetimeout: 10800 # 3 hrs
+  # which browser to use
+  browser:
+    name: chrome
+    # use remote browserstack browsers or not
+    use_browserstack: false
+    browserstack_username: xyz
+    browserstack_password: xyz
+    browserstack_access_key: xyz
 
 # 5. verification pass
 verificationpass:
-	sitetimeout: 10800 # 3 hrs
-	# which browser to use
-	browser:
-		name: chrome
-	endpoint: http://127.0.0.1:3456
-		
+  sitetimeout: 10800 # 3 hrs
+  # which browser to use
+  browser:
+    name: chrome
+  endpoint: http://127.0.0.1:3456
+
 
 # 5. choose the vulnerability analysis component to run
 # only one component must have the `enable` option as true
 domclobbering:
-	enabled: false
-	# enable or disable the passes, useful for large-scale analysis 
-	# e.g., first crawl all websites, then analyze them,
-	# as opposed to crawling and analyzing sequentially at the same time
-	passes:
-		crawling: false
-		static: false
-		static_neo4j: false
-		dynamic: false
+  enabled: false
+  # enable or disable the passes, useful for large-scale analysis 
+  # e.g., first crawl all websites, then analyze them,
+  # as opposed to crawling and analyzing sequentially at the same time
+  passes:
+    crawling: false
+    static: false
+    static_neo4j: false
+    dynamic: false
 
 
 cs_csrf:
-	enabled: false
-	passes:
-		crawling: false
-		static: false
-		static_neo4j: false
- 
+  enabled: false
+  passes:
+    crawling: false
+    static: false
+    static_neo4j: false
+
 
 request_hijacking:
-	enabled: true
-	passes:
-		crawling: false
-		static: true
-		static_neo4j: false
-		verification: false
+  enabled: true
+  passes:
+    crawling: false
+    static: true
+    static_neo4j: false
+    verification: false

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-screen -dmS s1 bash -c 'python3 -m run_pipeline --conf=config.yaml; exec sh'
+INEO_HOME=$(pwd)/ineo/ PATH=$INEO_HOME/bin:$PATH screen -dmS s1 bash -c 'python3 -m run_pipeline --conf=config.yaml; exec sh'


### PR DESCRIPTION
This pull request fixes two minor issues with the pipeline:

1. In the default `config.yaml`, tabs were used as indentation, which caused syntax errors with Python's TOML parser. This patch replaces tabs with spaces. (indent depth=2)
2. If the user does not export `$INEO_HOME` and `$PATH` again after a reboot (e.g., through .bashrc), INEO fails to install Neo4J and the cypher traversals cannot be performed in `run_pipeline.sh`. In the new version, these variables are dynamically set for JAW's process in the `run_pipeline.sh` script.