### PR TITLE
Fix Neo4J import in presence of compressed Foxhound edges and typo in request hijacking verifier command

### DIFF
--- a/engine/core/io/graphexporter.js
+++ b/engine/core/io/graphexporter.js
@@ -435,7 +435,7 @@ GraphExporter.prototype.decompressGraph = function (webpageFolder){
     cmd = `pigz -d ${relsFile}`;
     execSync(cmd);
 
-    if (fs.existsSync(relsFileDynamic)){
+    if (fs.existsSync(`${relsFileDynamic}.gz`)){
         cmd = `pigz -d ${relsFileDynamic}`;
         execSync(cmd);
     }

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -344,7 +344,7 @@ def main():
 			# dynamic verification
 			if config['request_hijacking']['passes']['verification']:
 				LOGGER.info("dynamic data flow verification for site %s."%(website_url))
-				cmd = node_dynamic_verifier.replace("SEED_URL", website_url)
+				cmd = node_dynamic_verifier.replace("SITE_URL", website_url)
 				request_hijacking_verification_api.start_verification_for_site(cmd, website_url, cwd=dynamic_verifier_command_cwd, timeout=verification_pass_timeout, overwrite=False)
 				LOGGER.info("sucessfully finished dynamic data flow verification for site %s."%(website_url))
 

--- a/utils/io.py
+++ b/utils/io.py
@@ -181,7 +181,7 @@ def decompress_graph(webpage_folder_path, node_file=constantsModule.NODE_INPUT_F
 	bash_command(cmd1)
 	bash_command(cmd2)
 
-	if os.path.exists(os.path.join(webpage_folder_path, edges_file_dynamic)):
+	if os.path.exists(os.path.join(webpage_folder_path, f"{edges_file_dynamic}.gz")):
 		cmd3="pigz %s"%(os.path.join(webpage_folder_path, edges_file_dynamic))
 		bash_command(cmd3)
 

--- a/utils/io.py
+++ b/utils/io.py
@@ -182,7 +182,7 @@ def decompress_graph(webpage_folder_path, node_file=constantsModule.NODE_INPUT_F
 	bash_command(cmd2)
 
 	if os.path.exists(os.path.join(webpage_folder_path, f"{edges_file_dynamic}.gz")):
-		cmd3="pigz %s"%(os.path.join(webpage_folder_path, edges_file_dynamic))
+		cmd3="pigz -d %s"%(os.path.join(webpage_folder_path, edges_file_dynamic))
 		bash_command(cmd3)
 
 


### PR DESCRIPTION
This PR fixes a small bug introduced in PR #19, where the target string of a replacement operation concerning the request hijacking verifier was modified by mistake from `SITE_URL` to `SEED_URL`.

```
node_dynamic_verfier_command = "node --max-old-space-size=4096 DRIVER_ENTRY --datadir={0} --website=**SITE_URL** --webpage=PAGE_URL_HASH --webpagedir=PAGE_URL_DIR --type=DYNAMIC_OR_STATIC --browser={1} --service={2}".format(
	constantsModule.DATA_DIR,
	config["verificationpass"]["browser"]["name"],
	config["verificationpass"]["endpoint"]
)
node_dynamic_verifier_driver_program = os.path.join(dynamic_verifier_command_cwd, "verify.js")
node_dynamic_verifier = node_dynamic_verfier_command.replace("DRIVER_ENTRY", node_dynamic_verifier_driver_program)
```