### PR TITLE
[DOM Clobbering] Add missing import to Cypher Query Script

### DIFF
--- a/analyses/domclobbering/domc_cypher_queries.py
+++ b/analyses/domclobbering/domc_cypher_queries.py
@@ -29,6 +29,7 @@ import os
 import sys
 import time
 import json
+import jsbeautifier
 import constants as constantsModule
 from utils.logging import logger as LOGGER
 from datetime import datetime


### PR DESCRIPTION
Currently, the DOM Clobbering queries crash for some pages, due to a missing `jsbeautifier` import required to treat some flow patterns.

This PR adds the missing import statement, so that all flows can be executed as intended.